### PR TITLE
Upgrade django dependency to less than 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 
 # Changelog
 
-## [3.0.1](https://pypi.org/project/directory_ch_client/3.0.0/) (2022-10-26)
+## [3.0.2](https://pypi.org/project/directory_ch_client/3.0.2/) (2023-02-16)
+[Full Changelog](https://github.com/uktrade/directory-companies-house-search-client/pull/14/files)
+### Implemented enhancements
+- KLS-397 - Upgrade Django to less than 4.0.0
+
+## [3.0.1](https://pypi.org/project/directory_ch_client/3.0.1/) (2022-10-26)
 [Full Changelog](https://github.com/uktrade/directory-companies-house-search-client/pull/13/files)
 
 ### Implemented enhancements

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description_content_type="text/markdown",
     include_package_data=True,
     install_requires=[
-        "django>=1.11.22,<4.0.0",
+        "django>=3.2.18,<4.0.0",
         "requests>=2.18.4,<3.0.0",
         "monotonic>=1.2,<3.0",
         "directory_client_core>=6.1.0,<8.0.0",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="directory_ch_client",
-    version="3.0.1",
+    version="3.0.2",
     url="https://github.com/uktrade/directory-companies-house-search-client",
     license="MIT",
     author="Department for International Trade",
@@ -12,7 +12,7 @@ setup(
     long_description_content_type="text/markdown",
     include_package_data=True,
     install_requires=[
-        "django>=1.11.22,<=3.2.16",
+        "django>=1.11.22,<4.0.0",
         "requests>=2.18.4,<3.0.0",
         "monotonic>=1.2,<3.0",
         "directory_client_core>=6.1.0,<8.0.0",


### PR DESCRIPTION
To do (delete all that do not apply):

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [x] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
