### PR TITLE
Remove changelog check from PR template & codecov version update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
             python3 -m venv .venv
             . .venv/bin/activate
             make test_requirements
-            make test
+            make test -- --codecov-token=${CODECOV_TOKEN}
   publish_to_pypi:
     docker:
       - image: cimg/python:3.9.13

--- a/makefile
+++ b/makefile
@@ -13,13 +13,16 @@ flake8:
 pytest:
 	pytest . --cov=. $(pytest_args)
 
-CODECOV := \
-	if [ "$$CODECOV_REPO_TOKEN" != "" ]; then \
-	   codecov --token=$$CODECOV_REPO_TOKEN ;\
-	fi
+pytest_codecov:
+	pytest \
+		--junitxml=test-reports/junit.xml \
+		--cov-config=.coveragerc \
+		--cov-report=term \
+		--cov=. \
+		--codecov \
+		$(ARGUMENTS)
 
-test: flake8 pytest
-	$(CODECOV)
+test: flake8 pytest_codecov
 
 integration_tests:
 	cd $(mktemp -d) && \

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,7 +1,7 @@
 To do (delete all that do not apply):
 
  - [ ] Change has a jira ticket that has the correct status.
- - [ ] Changelog entry added.
+ - [ ] A clear description/pull request message has been added.
  - [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
  - [ ] (if adding env vars) Added any new environment variable to vault.
  - [ ] (if adding feature flags) Cleaned up old flags

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="directory_ch_client",
-    version="3.0.2",
+    version="3.0.3",
     url="https://github.com/uktrade/directory-companies-house-search-client",
     license="MIT",
     author="Department for International Trade",
@@ -20,10 +20,11 @@ setup(
     extras_require={
         "test": [
             "pytest==7.1.3",
-            "pytest-cov==3.0.0",
+            "pytest-cov",
+            "pytest-codecov",
+            "GitPython",
             "flake8==5.0.4",
             "requests_mock==1.1.0",
-            "codecov>=2.0.16",
             "twine>=1.11.0,<2.0.0",
             "wheel>=0.31.0,<1.0.0",
             "setuptools>=38.6.0,<39.0.0",


### PR DESCRIPTION
This PR updates the PR template to no longer mention the changelog as we are no longer mantaining it.

To be able to unblock the CI pipeline, this PR also includes an update to our codecov configuration to use `pytest-codecov` rather than the outdated `codecov`

 - [x] Change has a jira ticket that has the correct status.